### PR TITLE
Add images to dialog responses

### DIFF
--- a/src/app/features/dialog/dialog-box/dialog-box.html
+++ b/src/app/features/dialog/dialog-box/dialog-box.html
@@ -21,6 +21,7 @@
                 *ngFor="let response of currentNode?.responses"
                 (click)="choose(response)"
             >
+                <img *ngIf="response.imageUrl" [src]="response.imageUrl" alt="" />
                 {{ response.label }}
             </button>
         </div>

--- a/src/app/features/dialog/dialog-box/dialog-box.scss
+++ b/src/app/features/dialog/dialog-box/dialog-box.scss
@@ -48,6 +48,15 @@
 
             button {
                 min-width: 160px;
+                display: flex;
+                align-items: center;
+                gap: 0.5rem;
+
+                img {
+                    width: 24px;
+                    height: 24px;
+                    object-fit: contain;
+                }
             }
         }
     }

--- a/src/app/features/dialog/dialog.model.ts
+++ b/src/app/features/dialog/dialog.model.ts
@@ -6,6 +6,7 @@ export interface DialogNode {
 
 export interface DialogResponse {
     label: string; // texte de la réponse
+    imageUrl?: string; // image optionnelle à afficher dans le bouton
     nextId?: string; // id de la prochaine question (si suite)
     action?: () => void; // ou action à exécuter (si fin de branche)
 }

--- a/src/app/features/shlagemon/choice-dialog/choice-dialog.ts
+++ b/src/app/features/shlagemon/choice-dialog/choice-dialog.ts
@@ -19,8 +19,16 @@ export class ChoiceDialog {
       id: 'start',
       text: 'Salut, tu veux quel Shlagémon ?',
       responses: [
-        { label: 'Schlartichaut', nextId: 'confirmSchlartichaut' },
-        { label: 'Draschlakofeu', nextId: 'confirmDraschlakofeu' }
+        {
+          label: 'Schlartichaut',
+          nextId: 'confirmSchlartichaut',
+          imageUrl: '/items/shlagéball/shlagéball.png'
+        },
+        {
+          label: 'Draschlakofeu',
+          nextId: 'confirmDraschlakofeu',
+          imageUrl: '/items/shlagéball/shlagéball.png'
+        }
       ]
     },
     {


### PR DESCRIPTION
## Summary
- allow `DialogResponse` to include an optional `imageUrl`
- display the optional image in response buttons
- style dialog box buttons for images
- show shlagéball image for each starter choice

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6852a327e570832aa10230cfea69fb8d