### PR TITLE
Add Schlagedex component to display Pokémon list

### DIFF
--- a/src/app/features/shlagemon/schlagedex/schlagedex.html
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.html
@@ -1,0 +1,10 @@
+<ng-container *ngIf="dex.shlagemons$ | async as mons">
+  <section *ngIf="mons.length > 0" class="schlagedex">
+    <h2 class="title">Schlagedex</h2>
+    <mat-list class="mon-list" role="list">
+      <mat-list-item role="listitem" *ngFor="let mon of mons">
+        {{ mon.name }}
+      </mat-list-item>
+    </mat-list>
+  </section>
+</ng-container>

--- a/src/app/features/shlagemon/schlagedex/schlagedex.scss
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.scss
@@ -1,0 +1,11 @@
+.schlagedex {
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+
+  .mon-list {
+    display: flex;
+    flex-direction: row;
+    gap: 1rem;
+  }
+}

--- a/src/app/features/shlagemon/schlagedex/schlagedex.spec.ts
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { Schlagedex } from './schlagedex';
+
+describe('Schlagedex', () => {
+  let component: Schlagedex;
+  let fixture: ComponentFixture<Schlagedex>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [Schlagedex]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(Schlagedex);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/shlagemon/schlagedex/schlagedex.ts
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.ts
@@ -1,0 +1,15 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatListModule } from '@angular/material/list';
+import { SchlagedexService } from '../schlagedex.service';
+
+@Component({
+  selector: 'app-schlagedex',
+  standalone: true,
+  imports: [CommonModule, MatListModule],
+  templateUrl: './schlagedex.html',
+  styleUrl: './schlagedex.scss'
+})
+export class Schlagedex {
+  constructor(public dex: SchlagedexService) {}
+}

--- a/src/app/layout/game/game.html
+++ b/src/app/layout/game/game.html
@@ -9,7 +9,7 @@
 
     </div>
     <div class="right">
-        right
+        <app-schlagedex />
     </div>
     <div class="top">
         top

--- a/src/app/layout/game/game.ts
+++ b/src/app/layout/game/game.ts
@@ -2,15 +2,17 @@ import { Component } from '@angular/core';
 import { Card } from '../card/card';
 import { GameStateService } from '../../core/game-state.service';
 import { ChoiceDialog } from '../../features/shlagemon/choice-dialog/choice-dialog';
+import { Schlagedex } from '../../features/shlagemon/schlagedex/schlagedex';
+import { SchlagedexService } from '../../features/shlagemon/schlagedex.service';
 
 @Component({
   selector: 'app-game',
-  imports: [ChoiceDialog],
+  imports: [ChoiceDialog, Schlagedex],
   templateUrl: './game.html',
   styleUrl: './game.scss'
 })
 export class Game {
 
-  constructor(private gameState: GameStateService) { }
+  constructor(private gameState: GameStateService, public dex: SchlagedexService) { }
 
 }


### PR DESCRIPTION
## Summary
- create Schlagedex component
- show Schlagedex in the game layout's right area
- register Schlagedex in game component

## Testing
- `npm test --silent` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6852a53f1cfc832a86effe31d160f503