### PR TITLE
Add Dex shlagemon factory with stats

### DIFF
--- a/src/app/features/shlagemon/choice-dialog/choice-dialog.ts
+++ b/src/app/features/shlagemon/choice-dialog/choice-dialog.ts
@@ -3,7 +3,7 @@ import { DialogBox } from '../../dialog/dialog-box/dialog-box';
 import { DialogNode } from '../../dialog/dialog.model';
 import { GameStateService } from '../../../core/game-state.service';
 import { SchlagedexService } from '../schlagedex.service';
-import { bulgrosboule, carapouffe, salamiches, Shlagemon } from '../../../shlagemons';
+import { bulgrosboule, carapouffe, salamiches, BaseShlagemon } from '../../../shlagemons';
 
 @Component({
   selector: 'app-choice-dialog',
@@ -15,15 +15,15 @@ export class ChoiceDialog {
 
   constructor(private gameState: GameStateService, private dex: SchlagedexService) { }
 
-  private shlagemonNextId(shlagemon: Shlagemon) {
+  private shlagemonNextId(shlagemon: BaseShlagemon) {
     return 'confirm' + shlagemon.name;
   }
 
-  private shlagemonImageUrl(shlagemon: Shlagemon) {
+  private shlagemonImageUrl(shlagemon: BaseShlagemon) {
     return `/shlagemons/${shlagemon.id}/${shlagemon.id}.png`;
   }
 
-  private generateResponse(shlagemon: Shlagemon) {
+  private generateResponse(shlagemon: BaseShlagemon) {
     return {
       label: shlagemon.name,
       nextId: this.shlagemonNextId(shlagemon),
@@ -74,7 +74,7 @@ export class ChoiceDialog {
         {
           label: 'Merci professeur Merdant',
           action: () => {
-            this.dex.createShlagemon('Schlartichaut');
+            this.dex.createShlagemon(carapouffe);
             this.gameState.setHasPokemon(true);
           }
         }
@@ -92,7 +92,7 @@ export class ChoiceDialog {
         {
           label: 'Génial !',
           action: () => {
-            this.dex.createShlagemon('Draschlakofeu');
+            this.dex.createShlagemon(salamiches);
             this.gameState.setHasPokemon(true);
           }
         }
@@ -111,7 +111,7 @@ export class ChoiceDialog {
         {
           label: 'Je l\'aime pas trop mais ok',
           action: () => {
-            this.dex.createShlagemon('Bulgrosbul');
+            this.dex.createShlagemon(bulgrosboule);
             this.gameState.setHasPokemon(true);
           }
         }

--- a/src/app/features/shlagemon/dex-shlagemon.factory.ts
+++ b/src/app/features/shlagemon/dex-shlagemon.factory.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@angular/core';
+import { BaseShlagemon } from '../../shlagemons';
+import { DexShlagemon } from './dex-shlagemon';
+
+@Injectable({ providedIn: 'root' })
+export class DexShlagemonFactory {
+  create(base: BaseShlagemon): DexShlagemon {
+    // Simple default stats for now
+    return new DexShlagemon(
+      base.id,
+      base.name,
+      base.color,
+      base.description,
+      base.type,
+      1, // rarity
+      50, // hp
+      10, // attack
+      10, // defense
+    );
+  }
+}

--- a/src/app/features/shlagemon/dex-shlagemon.ts
+++ b/src/app/features/shlagemon/dex-shlagemon.ts
@@ -1,0 +1,15 @@
+import { BaseShlagemon, Type } from '../../shlagemons';
+
+export class DexShlagemon implements BaseShlagemon {
+  constructor(
+    public id: string,
+    public name: string,
+    public color: string,
+    public description: string,
+    public type: Type,
+    public rarity: number,
+    public hp: number,
+    public attack: number,
+    public defense: number,
+  ) {}
+}

--- a/src/app/features/shlagemon/schlagedex.service.spec.ts
+++ b/src/app/features/shlagemon/schlagedex.service.spec.ts
@@ -10,9 +10,11 @@ describe('SchlagedexService', () => {
   });
 
   it('should create and store a shlagemon', () => {
-    service.createShlagemon('Schlartichaut');
+    const base = { id: 'schlartichaut', name: 'Schlartichaut', color: '', description: '', type: 'Slope' } as any;
+    service.createShlagemon(base);
     const mons = service.getShlagemons();
     expect(mons.length).toBe(1);
     expect(mons[0].name).toBe('Schlartichaut');
+    expect(mons[0].hp).toBeGreaterThan(0);
   });
 });

--- a/src/app/features/shlagemon/schlagedex.service.ts
+++ b/src/app/features/shlagemon/schlagedex.service.ts
@@ -1,23 +1,28 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { Shlagemon } from './shlagemon.model';
+import { DexShlagemon } from './dex-shlagemon';
+import { DexShlagemonFactory } from './dex-shlagemon.factory';
+import { BaseShlagemon } from '../../shlagemons';
 
 @Injectable({ providedIn: 'root' })
 export class SchlagedexService {
-  private monsSubject = new BehaviorSubject<Shlagemon[]>([]);
+  private monsSubject = new BehaviorSubject<DexShlagemon[]>([]);
   shlagemons$ = this.monsSubject.asObservable();
 
-  createShlagemon(name: string): Shlagemon {
-    const mon: Shlagemon = { id: name.toLowerCase(), name };
+  constructor(private factory: DexShlagemonFactory) {}
+
+  createShlagemon(base: BaseShlagemon): DexShlagemon {
+    const mon = this.factory.create(base);
     this.addShlagemon(mon);
     return mon;
   }
 
-  addShlagemon(mon: Shlagemon) {
+  addShlagemon(mon: DexShlagemon) {
     this.monsSubject.next([...this.monsSubject.value, mon]);
   }
 
-  getShlagemons(): Shlagemon[] {
+  getShlagemons(): DexShlagemon[] {
     return this.monsSubject.value;
   }
 }

--- a/src/app/features/shlagemon/shlagemon.model.ts
+++ b/src/app/features/shlagemon/shlagemon.model.ts
@@ -1,4 +1,11 @@
 export interface Shlagemon {
   id: string;
   name: string;
+  color: string;
+  description: string;
+  type: string;
+  rarity: number;
+  hp: number;
+  attack: number;
+  defense: number;
 }

--- a/src/app/shlagemons.ts
+++ b/src/app/shlagemons.ts
@@ -1,6 +1,6 @@
 export type Type = 'Slope' | 'Cuisine'
 
-export type Shlagemon = {
+export interface BaseShlagemon {
     id: string;
     name: string;
     color: string;
@@ -8,7 +8,7 @@ export type Shlagemon = {
     type: Type;
 }
 
-export const carapouffe: Shlagemon = {
+export const carapouffe: BaseShlagemon = {
     id: 'carapouffe',
     name: 'Carapouffe',
     color: '#333388',
@@ -17,7 +17,7 @@ export const carapouffe: Shlagemon = {
     type: 'Slope'
 };
 
-export const salamiches: Shlagemon = {
+export const salamiches: BaseShlagemon = {
     id: 'salamiches',
     name: 'Salamiches',
     color: '#ff5533',
@@ -27,7 +27,7 @@ export const salamiches: Shlagemon = {
     type: 'Cuisine'
 };
 
-export const bulgrosboule: Shlagemon = {
+export const bulgrosboule: BaseShlagemon = {
     id: 'bulgrosboule',
     name: 'Bulgrosboule',
     color: '#88ccff',


### PR DESCRIPTION
## Summary
- define `BaseShlagemon` data
- create `DexShlagemon` class with stats
- introduce `DexShlagemonFactory` to build mons with default stats
- update Schlagedex service to store full stat mons
- adjust choice dialog and tests

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68546e243b24832a8abf42ebdbb452f8