### PR TITLE
Implement Schlagedex modal with Material list

### DIFF
--- a/src/app/features/shlagemon/schlagedex/schlagedex.html
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.html
@@ -1,26 +1,12 @@
 <ng-container *ngIf="dex.shlagemons$ | async as mons">
   <section *ngIf="mons.length > 0" class="schlagedex">
     <h2 class="title">Schlagedex</h2>
-    <mat-list class="mon-list" role="list">
-      <mat-list-item role="listitem" *ngFor="let mon of mons" (click)="select(mon)">
-        {{ mon.name }}
+    <mat-list class="mon-list">
+      <mat-list-item *ngFor="let mon of mons" (click)="openDialog(mon)" class="mon-item">
+        <img matListAvatar [src]="imageUrl(mon)" [alt]="mon.name" />
+        <div matLine>{{ mon.name }}</div>
+        <div matLine class="secondary">{{ mon.type }}</div>
       </mat-list-item>
     </mat-list>
-    <mat-card class="mon-detail" *ngIf="selected">
-      <mat-card-header>
-        <mat-card-title>{{ selected.name }}</mat-card-title>
-        <mat-card-subtitle>{{ selected.type }}</mat-card-subtitle>
-      </mat-card-header>
-      <img mat-card-image [src]="imageUrl(selected)" [alt]="selected.name">
-      <mat-card-content>
-        <p>{{ selected.description }}</p>
-        <mat-list>
-          <mat-list-item>HP: {{ selected.hp }}</mat-list-item>
-          <mat-list-item>Attaque: {{ selected.attack }}</mat-list-item>
-          <mat-list-item>Défense: {{ selected.defense }}</mat-list-item>
-          <mat-list-item>Rareté: {{ selected.rarity }}</mat-list-item>
-        </mat-list>
-      </mat-card-content>
-    </mat-card>
   </section>
 </ng-container>

--- a/src/app/features/shlagemon/schlagedex/schlagedex.scss
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.scss
@@ -1,18 +1,7 @@
 .schlagedex {
-  display: flex;
-  flex-direction: column;
   padding: 1rem;
 
-  .mon-list {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    .mat-list-item {
-      cursor: pointer;
-    }
-  }
-
-  .mon-detail {
-    margin-top: 1rem;
+  .mon-item {
+    cursor: pointer;
   }
 }

--- a/src/app/features/shlagemon/schlagedex/schlagedex.ts
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.ts
@@ -1,24 +1,23 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatListModule } from '@angular/material/list';
-import { MatCardModule } from '@angular/material/card';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { ShlagemonDetailDialog } from './shlagemon-detail-dialog';
 import { SchlagedexService } from '../schlagedex.service';
 import { DexShlagemon } from '../dex-shlagemon';
 
 @Component({
   selector: 'app-schlagedex',
   standalone: true,
-  imports: [CommonModule, MatListModule, MatCardModule],
+  imports: [CommonModule, MatListModule, MatDialogModule, ShlagemonDetailDialog],
   templateUrl: './schlagedex.html',
   styleUrl: './schlagedex.scss'
 })
 export class Schlagedex {
-  selected?: DexShlagemon;
+  constructor(public dex: SchlagedexService, private dialog: MatDialog) {}
 
-  constructor(public dex: SchlagedexService) {}
-
-  select(mon: DexShlagemon) {
-    this.selected = mon;
+  openDialog(mon: DexShlagemon) {
+    this.dialog.open(ShlagemonDetailDialog, { data: mon });
   }
 
   imageUrl(mon: DexShlagemon) {

--- a/src/app/features/shlagemon/schlagedex/shlagemon-detail-dialog.html
+++ b/src/app/features/shlagemon/schlagedex/shlagemon-detail-dialog.html
@@ -1,0 +1,8 @@
+<h2 mat-dialog-title>{{ mon.name }}</h2>
+<mat-dialog-content>
+  <img [src]="imageUrl(mon)" [alt]="mon.name" class="mon-image" />
+  <p>{{ mon.description }}</p>
+</mat-dialog-content>
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Fermer</button>
+</mat-dialog-actions>

--- a/src/app/features/shlagemon/schlagedex/shlagemon-detail-dialog.ts
+++ b/src/app/features/shlagemon/schlagedex/shlagemon-detail-dialog.ts
@@ -1,0 +1,22 @@
+import { Component, Inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatDialogModule, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { DexShlagemon } from '../dex-shlagemon';
+
+@Component({
+  selector: 'app-shlagemon-detail-dialog',
+  standalone: true,
+  imports: [CommonModule, MatDialogModule, MatButtonModule],
+  templateUrl: './shlagemon-detail-dialog.html',
+})
+export class ShlagemonDetailDialog {
+  constructor(
+    public dialogRef: MatDialogRef<ShlagemonDetailDialog>,
+    @Inject(MAT_DIALOG_DATA) public mon: DexShlagemon,
+  ) { }
+
+  imageUrl(mon: DexShlagemon) {
+    return `/shlagemons/${mon.id}/${mon.id}.png`;
+  }
+}


### PR DESCRIPTION
## Summary
- show Schlagedex entries as a Material list with icon, name and type
- display Schlagémon details in a Material dialog

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_685475477af0832a999615805c5f19bd