### PR TITLE
Add persistent local storage with reset

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -5,6 +5,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { LayoutModule } from '@angular/cdk/layout';
 import { Header } from './layout/header/header';
 import { ThemeService } from './layout/theme/theme.service';
+import { StorageService } from './core/storage.service';
 import { MatButtonModule } from '@angular/material/button';
 import { Game } from './layout/game/game';
 
@@ -16,5 +17,5 @@ import { Game } from './layout/game/game';
 })
 export class App {
   protected title = 'chinpokomon';
-  constructor(public theme: ThemeService) { }
+  constructor(public theme: ThemeService, _storage: StorageService) { }
 }

--- a/src/app/core/storage.service.ts
+++ b/src/app/core/storage.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { SchlagedexService } from '../features/shlagemon/schlagedex.service';
+import { GameStateService } from './game-state.service';
+import { DexShlagemon } from '../features/shlagemon/dex-shlagemon';
+
+interface SaveData {
+  shlagemons: DexShlagemon[];
+}
+
+@Injectable({ providedIn: 'root' })
+export class StorageService {
+  private readonly key = 'save';
+
+  constructor(private dex: SchlagedexService, private game: GameStateService) {
+    this.load();
+    this.dex.shlagemons$.subscribe(() => this.save());
+  }
+
+  private load() {
+    if (typeof localStorage === 'undefined') return;
+    const raw = localStorage.getItem(this.key);
+    if (!raw) return;
+    try {
+      const data: SaveData = JSON.parse(raw);
+      if (data.shlagemons) {
+        this.dex.setShlagemons(data.shlagemons);
+        if (data.shlagemons.length > 0) {
+          this.game.setHasPokemon(true);
+        }
+      }
+    } catch (e) {
+      console.error('Failed to parse save data', e);
+    }
+  }
+
+  private save() {
+    if (typeof localStorage === 'undefined') return;
+    const data: SaveData = {
+      shlagemons: this.dex.getShlagemons(),
+    };
+    localStorage.setItem(this.key, JSON.stringify(data));
+  }
+
+  reset() {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.removeItem(this.key);
+    }
+    this.dex.clear();
+    this.game.reset();
+  }
+}

--- a/src/app/features/shlagemon/schlagedex.service.ts
+++ b/src/app/features/shlagemon/schlagedex.service.ts
@@ -22,6 +22,14 @@ export class SchlagedexService {
     this.monsSubject.next([...this.monsSubject.value, mon]);
   }
 
+  setShlagemons(mons: DexShlagemon[]) {
+    this.monsSubject.next([...mons]);
+  }
+
+  clear() {
+    this.monsSubject.next([]);
+  }
+
   getShlagemons(): DexShlagemon[] {
     return this.monsSubject.value;
   }

--- a/src/app/layout/header/header.html
+++ b/src/app/layout/header/header.html
@@ -34,6 +34,8 @@
         </mat-slide-toggle> -->
 
         <theme-toggle />
-
+        <button mat-icon-button (click)="reset()" aria-label="Reset Save">
+            <mat-icon>delete</mat-icon>
+        </button>
     </span>
 </mat-toolbar>

--- a/src/app/layout/header/header.ts
+++ b/src/app/layout/header/header.ts
@@ -5,6 +5,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { ThemeToggleComponent } from '../theme/theme-toggle.component';
+import { StorageService } from '../../core/storage.service';
 
 @Component({
   selector: 'app-header',
@@ -21,5 +22,9 @@ import { ThemeToggleComponent } from '../theme/theme-toggle.component';
   standalone: true
 })
 export class Header {
-  constructor() { }
+  constructor(private storage: StorageService) { }
+
+  reset() {
+    this.storage.reset();
+  }
 }


### PR DESCRIPTION
## Summary
- save and load the dex automatically with a new `StorageService`
- reset stored data from the header
- inject the storage service on app startup

## Testing
- `npm test` *(fails: No Chrome binary)*

------
https://chatgpt.com/codex/tasks/task_e_6854823bc40c832a8771ffd09c3e1b01