### PR TITLE
Add responsive layout mixins

### DIFF
--- a/src/app/layout/game/game.scss
+++ b/src/app/layout/game/game.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/variables' as vars;
+
 // 🎛 Variables de grille
 $grid-size: 12;
 $col-count: $grid-size;
@@ -81,4 +83,17 @@ $center-row-span: $row-count - $top-row-span - $bottom-row-span;
 .bottom {
     grid-column: $bottom-col-start / span $bottom-col-span;
     grid-row: $bottom-row-start / span $bottom-row-span;
+}
+
+@include vars.respond(sm) {
+    .game {
+        display: flex;
+        flex-direction: column;
+        height: auto;
+    }
+
+    .zone {
+        height: auto;
+        width: 100%;
+    }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,5 @@
 @use '@angular/material' as mat;
+@use 'styles/variables' as vars;
 
 $my-typography: (
     plain-family: 'Roboto',
@@ -46,6 +47,12 @@ body {
     height: 100%;
     overflow: auto;
     box-sizing: border-box;
+}
+
+@include vars.respond(sm) {
+    .full {
+        overflow: visible;
+    }
 }
 
 .f-flex {

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,0 +1,20 @@
+$breakpoints: (
+  sm: 600px,
+  md: 960px,
+  lg: 1280px,
+  xl: 1920px,
+);
+
+@mixin respond($size, $type: max) {
+  $value: map-get($breakpoints, $size);
+  @if $type == max {
+    @media (max-width: $value) {
+      @content;
+    }
+  } @else if $type == min {
+    @media (min-width: $value) {
+      @content;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add global SCSS variables and `respond` mixin
- use the mixin in global styles to disable overflow on mobile
- apply mobile-friendly column layout to `game` component

## Testing
- `npm test --silent --no-progress --no-watch` *(fails: No Chrome binary found)*

------
https://chatgpt.com/codex/tasks/task_e_68558961da38832aa1645f6b9f0ef533