### PR TITLE
Add active shlagémon selection

### DIFF
--- a/src/app/features/panels/main/main.ts
+++ b/src/app/features/panels/main/main.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SchlagedexService } from '../../shlagemon/schlagedex.service';
-import { Observable, map } from 'rxjs';
+import { Observable } from 'rxjs';
 import { DexShlagemon } from '../../shlagemon/dex-shlagemon';
 
 @Component({
@@ -12,10 +12,10 @@ import { DexShlagemon } from '../../shlagemon/dex-shlagemon';
   styleUrl: './main.scss'
 })
 export class SelectedShlagemon {
-  mon$!: Observable<DexShlagemon | undefined>;
+  mon$!: Observable<DexShlagemon | null>;
 
   constructor(private dex: SchlagedexService) {
-    this.mon$ = this.dex.shlagemons$.pipe(map(mons => mons[0]));
+    this.mon$ = this.dex.activeShlagemon$;
   }
 
   imageUrl(id: string) {

--- a/src/app/features/shlagemon/schlagedex.service.ts
+++ b/src/app/features/shlagemon/schlagedex.service.ts
@@ -9,16 +9,30 @@ export class SchlagedexService {
   private monsSubject = new BehaviorSubject<DexShlagemon[]>([]);
   shlagemons$ = this.monsSubject.asObservable();
 
+  private activeMonSubject = new BehaviorSubject<DexShlagemon | null>(null);
+  activeShlagemon$ = this.activeMonSubject.asObservable();
+
   constructor(private factory: DexShlagemonFactory) { }
 
   createShlagemon(base: BaseShlagemon): DexShlagemon {
     const mon = this.factory.create(base);
     this.addShlagemon(mon);
+    if (!this.activeMonSubject.value) {
+      this.setActiveShlagemon(mon);
+    }
     return mon;
   }
 
   addShlagemon(mon: DexShlagemon) {
     this.monsSubject.next([...this.monsSubject.value, mon]);
+  }
+
+  setActiveShlagemon(mon: DexShlagemon) {
+    this.activeMonSubject.next(mon);
+  }
+
+  getActiveShlagemon(): DexShlagemon | null {
+    return this.activeMonSubject.value;
   }
 
   setShlagemons(mons: DexShlagemon[]) {

--- a/src/app/features/shlagemon/schlagedex/schlagedex.html
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.html
@@ -8,6 +8,7 @@
       @for (mon of mons; track mon) {
       <div
         class="list-item"
+        [class.active]="dex.getActiveShlagemon()?.id === mon.id"
         (click)="openDialog(mon)"
       >
         <div class="f-flex">
@@ -19,6 +20,13 @@
 
         </div>
         <shlagemon-type [value]="mon.type"></shlagemon-type>
+        <button
+          mat-icon-button
+          (click)="dex.setActiveShlagemon(mon); $event.stopPropagation()"
+          aria-label="Select {{mon.name}}"
+        >
+          <mat-icon>check</mat-icon>
+        </button>
       </div>
       }
     </div>

--- a/src/app/features/shlagemon/schlagedex/schlagedex.scss
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.scss
@@ -26,6 +26,11 @@
         height: 40px;
         object-fit: contain;
       }
+
+      &.active {
+        background-color: var(--md-sys-color-primary);
+        color: var(--md-sys-color-on-primary);
+      }
     }
   }
 

--- a/src/app/features/shlagemon/schlagedex/schlagedex.ts
+++ b/src/app/features/shlagemon/schlagedex/schlagedex.ts
@@ -6,12 +6,13 @@ import { ShlagemonDetailDialog } from './shlagemon-detail-dialog';
 import { SchlagedexService } from '../schlagedex.service';
 import { DexShlagemon } from '../dex-shlagemon';
 import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 import { ShlagemonType } from "../shlagemon-type/shlagemon-type";
 
 @Component({
   selector: 'app-schlagedex',
   standalone: true,
-  imports: [ShlagemonType, CommonModule, MatListModule, MatDialogModule, MatIconModule],
+  imports: [ShlagemonType, CommonModule, MatListModule, MatDialogModule, MatIconModule, MatButtonModule],
   templateUrl: './schlagedex.html',
   styleUrl: './schlagedex.scss'
 })


### PR DESCRIPTION
## Summary
- allow tracking of the currently active shlagémon
- show the selected shlagémon panel using that active value
- add icon button in shlagédex to select a shlagémon
- highlight the active entry with primary colors

## Testing
- `npm test` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_68558e8c1be0832abfaa4e47b19b577d