### PR TITLE
Fix standalone module import

### DIFF
--- a/src/app/features/battle/battle.module.ts
+++ b/src/app/features/battle/battle.module.ts
@@ -4,8 +4,8 @@ import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MainPanelComponent } from './main-panel/main-panel.component';
 
 @NgModule({
-  declarations: [MainPanelComponent],
-  imports: [CommonModule, MatProgressBarModule],
+  declarations: [],
+  imports: [CommonModule, MatProgressBarModule, MainPanelComponent],
   exports: [MainPanelComponent]
 })
 export class BattleModule {}


### PR DESCRIPTION
## Summary
- include `MainPanelComponent` in module imports for `BattleModule`

## Testing
- `npm run build --silent`
- `npm test --silent` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6856cdcefa50832a837a8959fac5c0c9